### PR TITLE
feat: add script to apply ESA quality mask

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@
 
 ## Usage
 ```bash
+$ apply_s2_quality_mask INPUTS2DIR
+```
+```bash
 $ check_solar_zenith_sentinel INPUTXML
 ```
 ```bash

--- a/apply_s2_quality_mask/apply_s2_quality_mask.py
+++ b/apply_s2_quality_mask/apply_s2_quality_mask.py
@@ -5,21 +5,16 @@ import click
 import rasterio
 
 
-# FIXME: restrict this to bands that are used by HLS
+# MSI band number definitions for bands used by HLS v2 product
+# (coastal, blue/green/red, NIR, SWIR1, SWIR2)
 SPECTRAL_BANDS = frozenset({
     "B01",
     "B02",
     "B03",
     "B04",
-    "B05",
-    "B06",
-    "B07",
-    "B08",
-    "B09",
-    "B10",
+    "B8A",
     "B11",
     "B12",
-    "B8A",
 })
 
 

--- a/apply_s2_quality_mask/apply_s2_quality_mask.py
+++ b/apply_s2_quality_mask/apply_s2_quality_mask.py
@@ -1,0 +1,133 @@
+from typing import List, Optional, Tuple
+from pathlib import Path
+
+import click
+import rasterio
+
+
+# FIXME: restrict this to bands that are used by HLS
+SPECTRAL_BANDS = frozenset({
+    "B01",
+    "B02",
+    "B03",
+    "B04",
+    "B05",
+    "B06",
+    "B07",
+    "B08",
+    "B09",
+    "B10",
+    "B11",
+    "B12",
+    "B8A",
+})
+
+
+def _one_or_none(paths: List[Path]) -> Optional[Path]:
+    if len(paths) == 1:
+        return paths[0]
+
+
+def find_image_mask_pairs(granule_dir: Path) -> List[Tuple[Path, Path]]:
+    """Search granule directory for image + mask pairs
+
+    The quality masks were produced in an imagery format since baseline 04.00
+    (~Jan 25, 2022 and onward), so this function might return nothing
+    if run on granules created with older baselines. These older baselines
+    encoded the mask quality information in the GML (vector) format.
+
+    The relevant parts of an unzipped granule looks like,
+    ```
+    ${GRANULE_ID}.SAFE
+    ${GRANULE_ID}.SAFE/GRANULE
+    ${GRANULE_ID}.SAFE/GRANULE/L1C_T45TXF_A038726_20221121T050115
+    ${GRANULE_ID}.SAFE/GRANULE/L1C_T45TXF_A038726_20221121T050115/IMG_DATA
+    ${GRANULE_ID}.SAFE/GRANULE/L1C_T45TXF_A038726_20221121T050115/IMG_DATA/T45TXF_20221121T050121_B01.jp2
+    ... (*B*.jp2)
+    ${GRANULE_ID}.SAFE/GRANULE/L1C_T45TXF_A038726_20221121T050115/QI_DATA
+    ${GRANULE_ID}.SAFE/GRANULE/L1C_T45TXF_A038726_20221121T050115/QI_DATA/MSK_QUALIT_B01.jp2
+    ... (MSK_QUALIT_B*.jp2)
+    ```
+
+    References
+    ----------
+    https://sentinels.copernicus.eu/web/sentinel/-/copernicus-sentinel-2-major-products-upgrade-upcoming
+    """
+    pairs = []
+    for band in SPECTRAL_BANDS:
+        image = _one_or_none(list(granule_dir.glob(f"**/IMG_DATA/*{band}.jp2")))
+        mask = _one_or_none(list(granule_dir.glob(f"**/QI_DATA/MSK_QUALIT_{band}.jp2")))
+        if image and mask:
+            pairs.append((image, mask))
+
+    # Find all bands, or none
+    if len(pairs) == len(SPECTRAL_BANDS):
+        return pairs
+    return []
+
+
+def apply_quality_mask(image: Path, mask: Path):
+    """Apply Sentinel-2 image quality mask
+
+    Each spectral band (`IMG_DATA/B*.jp2`) has a corresponding quality mask
+    image (`QI_DATA/MSK_QUALIT_B*.jp2`) of the same spatial resolution. The mask
+    image has 8 bands, with each band encoding a boolean for the presence/absence
+    of a quality issue. The bands indicate,
+
+    1: lost ancillary packets
+    2: degraded ancillary packets
+    3: lost MSI packets
+    4: degraded MSI packets
+    5: defective pixels
+    6: no data
+    7: partially corrected cross talk
+    8: saturated pixels
+
+    We have decided to mask 3 (lost MSI packets) and 4 (degraded MSI packets) only.
+    So far, 5 and 7 are present in  B10-B11, because interpolation is used to fill 5
+    and the cross talk is partially corrected.
+    Saturated pixels are still useful for the magnitude of the reflectance; keep it.
+
+    We apply the mask by updating the spectral data images in-place rather than
+    creating another file.
+
+    References
+    ----------
+    https://sentinels.copernicus.eu/web/sentinel/technical-guides/sentinel-2-msi/data-quality-reports
+    """
+    with rasterio.open(mask) as mask_src:
+        qa_bands = mask_src.read(indexes=[3, 4])
+        lost_degraded_mask = (qa_bands == 1).any(axis=0)
+
+    # only update imagery if mask shows it has any bad pixels
+    if lost_degraded_mask.any():
+        click.echo(f"Masking lost or degraded pixel values in {image}")
+        with rasterio.open(image, "r+") as img_src:
+            img = img_src.read(1)
+            # L1C images don't define the nodata value on file so we can't update the
+            # mask (e.g., via `write_mask`) but 0 is used as the nodata value
+            # (see SPECIAL_VALUE_INDEX for NODATA in metadata)
+            img[lost_degraded_mask] = 0
+            img_src.write(img, indexes=1)
+
+
+@click.command()
+@click.argument(
+    "granule_dir",
+    type=click.Path(file_okay=False, dir_okay=True, exists=True),
+)
+def main(granule_dir: Path):
+    """Update Sentinel-2 imagery by masking lost or degraded pixels"""
+    granule_dir = Path(granule_dir)
+    click.echo(f"Applying Sentinel-2 QAQC mask to granule_dir={granule_dir}")
+
+    image_mask_pairs = find_image_mask_pairs(granule_dir)
+
+    for (image, mask) in image_mask_pairs:
+        apply_quality_mask(image, mask)
+
+    click.echo("Complete")
+
+
+if __name__ == "__main__":
+    main()

--- a/apply_s2_quality_mask/apply_s2_quality_mask.py
+++ b/apply_s2_quality_mask/apply_s2_quality_mask.py
@@ -166,7 +166,7 @@ def apply_quality_mask(image: Path, mask: Path):
     type=click.Path(file_okay=False, dir_okay=True, exists=True),
 )
 @click.pass_context
-def main(ctx, granule_dir: Path):
+def main(ctx, granule_dir: str):
     """Update Sentinel-2 imagery by masking lost or degraded pixels"""
     granule_dir = Path(granule_dir)
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,9 @@ setup(
         "click~=7.1.0",
         "lxml",
         "boto3~=1.17.91",
-        "espa-python-library @ git+https://github.com/USGS-EROS/espa-python-library.git@v2.0.0#egg=espa-python-library"
+        "espa-python-library @ git+https://github.com/USGS-EROS/espa-python-library.git@v2.0.0#egg=espa-python-library",
+        "rasterio~=1.2",
+        "numpy~=1.16",
     ],
     include_package_data=True,
     extras_require={
@@ -16,6 +18,7 @@ setup(
         "test": ["flake8", "pytest", "Jinja2==2.10.1", "moto[s3]~=2.0.8"]
     },
     entry_points={"console_scripts": [
+        "apply_s2_quality_mask=apply_s2_quality_mask.apply_s2_quality_mask:main",
         "parse_fmask=parse_fmask.parse_fmask:main",
         "check_solar_zenith_sentinel=check_solar_zenith_sentinel.check_solar_zenith_sentinel:main",
         "check_solar_zenith_landsat=check_solar_zenith_landsat.check_solar_zenith_landsat:main",

--- a/tests/data/quality-mask/L1C_T12QXM_A048143_20240909T175112/QI_DATA/GENERAL_QUALITY.xml
+++ b/tests/data/quality-mask/L1C_T12QXM_A048143_20240909T175112/QI_DATA/GENERAL_QUALITY.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?><Earth_Explorer_File xmlns="http://gs2.esa.int/DATA_STRUCTURE/olqcReport">
+    <Earth_Explorer_Header>
+        <Fixed_Header>
+            <File_Name>GRANULE/L1C_T12QXM_A048143_20240909T175112/QI_DATA/GENERAL_QUALITY.xml</File_Name>
+            <File_Description>Report produced by OLQC-SC</File_Description>
+            <Notes/>
+            <Mission>S2A</Mission>
+            <File_Class>OPER</File_Class>
+            <File_Type>REP_OLQCPA</File_Type>
+            <Validity_Period>
+                <Validity_Start>UTC=2024-07-23T03:00:00</Validity_Start>
+                <Validity_Stop>UTC=2100-01-01T00:00:00</Validity_Stop>
+            </Validity_Period>
+            <File_Version>2</File_Version>
+            <Source>
+                <System>OLQC-SC</System>
+                <Creator>OLQC-SC</Creator>
+                <Creator_Version>06.03.00</Creator_Version>
+                <Creation_Date>UTC=2024-09-10T00:44:41</Creation_Date>
+            </Source>
+        </Fixed_Header>
+    </Earth_Explorer_Header>
+    <Data_Block type="xml">
+        <report date="2024-09-10T00:44:41.058Z" gippVersion="1.0" globalStatus="PASSED">
+            <checkList>
+                <parentID>S2A_OPER_GIP_OLQCPA_MPC__20240717T000043_V20240723T030000</parentID>
+                <name>GENERAL_QUALITY</name>
+                <version>1.0</version>
+                <item class="http://www.esa.int/s2#pdi_level_1c_tile_container" className="PDI Level 1C Tile Folder" name="S2A_OPER_MSI_L1C_TL_2APS_20240909T231016_A048143_T12QXM_N05.11" url="/mnt/nfs-l1-03/l1-processing/processing-id-65140-2024-09-09-23-34-02/TaskTable_20240909T233403/FORMAT_METADATA_TILE_L1C_ADAPT/output/PDI_DS_TILE_LIST/S2A_OPER_MSI_L1C_TL_2APS_20240909T231016_A048143_T12QXM_N05.11/"/>
+                <check>
+                    <inspection creation="2024-09-10T00:44:40.633Z" duration="357" execution="2024-09-10T00:44:40.672Z" id="Solar_Angle_Zenith" item="S2A_OPER_MTD_L1C_TL_2APS_20240909T231016_A048143_T12QXM.xml" itemURL="/mnt/nfs-l1-03/l1-processing/processing-id-65140-2024-09-09-23-34-02/TaskTable_20240909T233403/FORMAT_METADATA_TILE_L1C_ADAPT/output/PDI_DS_TILE_LIST/S2A_OPER_MSI_L1C_TL_2APS_20240909T231016_A048143_T12QXM_N05.11/S2A_OPER_MTD_L1C_TL_2APS_20240909T231016_A048143_T12QXM.xml" name="Check the zenith solar angle. " priority="5" processingStatus="done" status="PASSED"/>
+                    <message contentType="text/plain">Zenith solar angle (26.6116855171579) is within the threshold limit (82.0) </message>
+                    <extraValues>
+                        <value name="EXPECTED">82.0</value>
+                        <value name="SOLAR_ZENITH_ANGLE">26.6116855171579</value>
+                    </extraValues>
+                </check>
+                <check>
+                    <inspection creation="2024-09-10T00:44:41.909Z" duration="16" execution="2024-09-10T00:44:41.914Z" id="checkMetadata" item="S2A_OPER_MSI_L1C_TL_2APS_20240909T231016_A048143_T12QXM_N05.11" itemURL="/mnt/nfs-l1-03/l1-processing/processing-id-65140-2024-09-09-23-34-02/TaskTable_20240909T233403/FORMAT_METADATA_TILE_L1C_ADAPT/output/PDI_DS_TILE_LIST/S2A_OPER_MSI_L1C_TL_2APS_20240909T231016_A048143_T12QXM_N05.11/" name="Metadata file check. " priority="5" processingStatus="done" status="PASSED"/>
+                    <message contentType="text/plain">Metadata file is present.</message>
+                </check>
+                <check>
+                    <inspection creation="2024-09-10T00:44:43.339Z" duration="11692" execution="2024-09-10T00:44:43.350Z" id="Data_Loss" item="S2A_OPER_MSI_L1C_TL_2APS_20240909T231016_A048143_T12QXM_N05.11" itemURL="/mnt/nfs-l1-03/l1-processing/processing-id-65140-2024-09-09-23-34-02/TaskTable_20240909T233403/FORMAT_METADATA_TILE_L1C_ADAPT/output/PDI_DS_TILE_LIST/S2A_OPER_MSI_L1C_TL_2APS_20240909T231016_A048143_T12QXM_N05.11/" name="Check TECQUA for data loss " priority="5" processingStatus="done" status="PASSED"/>
+                    <message contentType="text/plain">No data loss in this tile.</message>
+                </check>
+            </checkList>
+        </report>
+    </Data_Block>
+</Earth_Explorer_File>

--- a/tests/data/quality-mask/L1C_T43QDG_A031305_20230305T053523/QI_DATA/GENERAL_QUALITY.xml
+++ b/tests/data/quality-mask/L1C_T43QDG_A031305_20230305T053523/QI_DATA/GENERAL_QUALITY.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?><Earth_Explorer_File xmlns="http://gs2.esa.int/DATA_STRUCTURE/olqcReport">
+    <Earth_Explorer_Header>
+        <Fixed_Header>
+            <File_Name>GRANULE/L1C_T43QDG_A031305_20230305T053523/QI_DATA/GENERAL_QUALITY.xml</File_Name>
+            <File_Description>Report produced by OLQC-SC</File_Description>
+            <Notes/>
+            <Mission>S2B</Mission>
+            <File_Class>OPER</File_Class>
+            <File_Type>REP_OLQCPA</File_Type>
+            <Validity_Period>
+                <Validity_Start>UTC=2022-08-30T00:25:00</Validity_Start>
+                <Validity_Stop>UTC=2100-01-01T00:00:00</Validity_Stop>
+            </Validity_Period>
+            <File_Version>2</File_Version>
+            <Source>
+                <System>OLQC-SC</System>
+                <Creator>OLQC-SC</Creator>
+                <Creator_Version>06.01.00</Creator_Version>
+                <Creation_Date>UTC=2023-03-05T08:36:44</Creation_Date>
+            </Source>
+        </Fixed_Header>
+    </Earth_Explorer_Header>
+    <Data_Block type="xml">
+        <report date="2023-03-05T08:36:44.399Z" gippVersion="1.0" globalStatus="FAILED">
+            <checkList>
+                <parentID>S2B_OPER_GIP_OLQCPA_MPC__20220715T000042_V20220830T002500</parentID>
+                <name>GENERAL_QUALITY</name>
+                <version>1.0</version>
+                <item class="http://www.esa.int/s2#pdi_level_1c_tile_container" className="PDI Level 1C Tile Folder" name="S2B_OPER_MSI_L1C_TL_2BPS_20230305T072429_A031305_T43QDG_N05.09" url="/mnt/local/l1ctile/work/3be743a1-28c3-4010-84c9-8ccca1586310/ipf_output_L1CTile_20230305082123/L1CTile/TaskTable_20230305T082127/FORMAT_METADATA_TILE_L1C/output/PDI_DS_TILE_LIST/S2B_OPER_MSI_L1C_TL_2BPS_20230305T072429_A031305_T43QDG_N05.09/"/>
+                <check>
+                    <inspection creation="2023-03-05T08:36:44.100Z" duration="246" execution="2023-03-05T08:36:44.145Z" id="checkMetadata" item="S2B_OPER_MSI_L1C_TL_2BPS_20230305T072429_A031305_T43QDG_N05.09" itemURL="/mnt/local/l1ctile/work/3be743a1-28c3-4010-84c9-8ccca1586310/ipf_output_L1CTile_20230305082123/L1CTile/TaskTable_20230305T082127/FORMAT_METADATA_TILE_L1C/output/PDI_DS_TILE_LIST/S2B_OPER_MSI_L1C_TL_2BPS_20230305T072429_A031305_T43QDG_N05.09/" name="Metadata file check. " priority="5" processingStatus="done" status="PASSED"/>
+                    <message contentType="text/plain">Metadata file is present.</message>
+                </check>
+                <check>
+                    <inspection creation="2023-03-05T08:36:45.387Z" duration="81" execution="2023-03-05T08:36:45.397Z" id="Solar_Angle_Zenith" item="S2B_OPER_MTD_L1C_TL_2BPS_20230305T072429_A031305_T43QDG.xml" itemURL="/mnt/local/l1ctile/work/3be743a1-28c3-4010-84c9-8ccca1586310/ipf_output_L1CTile_20230305082123/L1CTile/TaskTable_20230305T082127/FORMAT_METADATA_TILE_L1C/output/PDI_DS_TILE_LIST/S2B_OPER_MSI_L1C_TL_2BPS_20230305T072429_A031305_T43QDG_N05.09/S2B_OPER_MTD_L1C_TL_2BPS_20230305T072429_A031305_T43QDG.xml" name="Check the zenith solar angle. " priority="5" processingStatus="done" status="PASSED"/>
+                    <message contentType="text/plain">Zenith solar angle (37.349671777297) is within the threshold limit (82.0) </message>
+                    <extraValues>
+                        <value name="EXPECTED">82.0</value>
+                        <value name="SOLAR_ZENITH_ANGLE">37.349671777297</value>
+                    </extraValues>
+                </check>
+                <check>
+                    <inspection creation="2023-03-05T08:36:45.870Z" duration="23651" execution="2023-03-05T08:36:45.877Z" id="Data_Loss" item="S2B_OPER_MSI_L1C_TL_2BPS_20230305T072429_A031305_T43QDG_N05.09" itemURL="/mnt/local/l1ctile/work/3be743a1-28c3-4010-84c9-8ccca1586310/ipf_output_L1CTile_20230305082123/L1CTile/TaskTable_20230305T082127/FORMAT_METADATA_TILE_L1C/output/PDI_DS_TILE_LIST/S2B_OPER_MSI_L1C_TL_2BPS_20230305T072429_A031305_T43QDG_N05.09/" name="Check TECQUA for data loss " priority="5" processingStatus="done" status="FAILED"/>
+                    <message contentType="text/plain">There is data loss in this tile</message>
+                    <extraValues>
+                        <value name="Affected_Bands">B01 B02 B03 B09 B10 B11 B12 B8A</value>
+                    </extraValues>
+                </check>
+            </checkList>
+        </report>
+    </Data_Block>
+</Earth_Explorer_File>

--- a/tests/data/quality-mask/L1C_T45TXF_A038726_20221121T050115/QI_DATA/GENERAL_QUALITY.xml
+++ b/tests/data/quality-mask/L1C_T45TXF_A038726_20221121T050115/QI_DATA/GENERAL_QUALITY.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?><Earth_Explorer_File xmlns="http://gs2.esa.int/DATA_STRUCTURE/olqcReport">
+    <Earth_Explorer_Header>
+        <Fixed_Header>
+            <File_Name>GRANULE/L1C_T45TXF_A038726_20221121T050115/QI_DATA/GENERAL_QUALITY.xml</File_Name>
+            <File_Description>Report produced by OLQC-SC</File_Description>
+            <Notes/>
+            <Mission>S2A</Mission>
+            <File_Class>OPER</File_Class>
+            <File_Type>REP_OLQCPA</File_Type>
+            <Validity_Period>
+                <Validity_Start>UTC=2022-08-30T00:25:00</Validity_Start>
+                <Validity_Stop>UTC=2100-01-01T00:00:00</Validity_Stop>
+            </Validity_Period>
+            <File_Version>2</File_Version>
+            <Source>
+                <System>OLQC-SC</System>
+                <Creator>OLQC-SC</Creator>
+                <Creator_Version>05.01.00</Creator_Version>
+                <Creation_Date>UTC=2022-11-21T07:37:39</Creation_Date>
+            </Source>
+        </Fixed_Header>
+    </Earth_Explorer_Header>
+    <Data_Block type="xml">
+        <report date="2022-11-21T07:37:39.124Z" gippVersion="1.0" globalStatus="FAILED">
+            <checkList>
+                <parentID>S2A_OPER_GIP_OLQCPA_MPC__20220715T000042_V20220830T002500</parentID>
+                <name>GENERAL_QUALITY</name>
+                <version>1.0</version>
+                <item class="http://www.esa.int/s2#pdi_level_1c_tile_container" className="PDI Level 1C Tile Folder" name="S2A_OPER_MSI_L1C_TL_ATOS_20221121T053331_A038726_T45TXF_N04.00" url="/mnt/nfs-l1-02/l1-processing/processing-id-17769-2022-11-21-06-03-12/TaskTable_20221121T060312/FORMAT_METADATA_TILE_L1C_ADAPT/output/PDI_DS_TILE_LIST/S2A_OPER_MSI_L1C_TL_ATOS_20221121T053331_A038726_T45TXF_N04.00/"/>
+                <check>
+                    <inspection creation="2022-11-21T07:37:38.889Z" duration="210" execution="2022-11-21T07:37:38.893Z" id="checkMetadata" item="S2A_OPER_MSI_L1C_TL_ATOS_20221121T053331_A038726_T45TXF_N04.00" itemURL="/mnt/nfs-l1-02/l1-processing/processing-id-17769-2022-11-21-06-03-12/TaskTable_20221121T060312/FORMAT_METADATA_TILE_L1C_ADAPT/output/PDI_DS_TILE_LIST/S2A_OPER_MSI_L1C_TL_ATOS_20221121T053331_A038726_T45TXF_N04.00/" name="Metadata file check. " priority="5" processingStatus="done" status="PASSED"/>
+                    <message contentType="text/plain">Metadata file is present.</message>
+                </check>
+                <check>
+                    <inspection creation="2022-11-21T07:37:41.147Z" duration="281" execution="2022-11-21T07:37:41.188Z" id="Solar_Angle_Zenith" item="S2A_OPER_MTD_L1C_TL_ATOS_20221121T053331_A038726_T45TXF.xml" itemURL="/mnt/nfs-l1-02/l1-processing/processing-id-17769-2022-11-21-06-03-12/TaskTable_20221121T060312/FORMAT_METADATA_TILE_L1C_ADAPT/output/PDI_DS_TILE_LIST/S2A_OPER_MSI_L1C_TL_ATOS_20221121T053331_A038726_T45TXF_N04.00/S2A_OPER_MTD_L1C_TL_ATOS_20221121T053331_A038726_T45TXF.xml" name="Check the zenith solar angle. " priority="5" processingStatus="done" status="PASSED"/>
+                    <message contentType="text/plain">Zenith solar angle (61.7640691258715) is within the threshold limit (82.0) </message>
+                    <extraValues>
+                        <value name="EXPECTED">82.0</value>
+                        <value name="SOLAR_ZENITH_ANGLE">61.7640691258715</value>
+                    </extraValues>
+                </check>
+                <check>
+                    <inspection creation="2022-11-21T07:37:42.488Z" duration="11940" execution="2022-11-21T07:37:42.495Z" id="Data_Loss" item="S2A_OPER_MSI_L1C_TL_ATOS_20221121T053331_A038726_T45TXF_N04.00" itemURL="/mnt/nfs-l1-02/l1-processing/processing-id-17769-2022-11-21-06-03-12/TaskTable_20221121T060312/FORMAT_METADATA_TILE_L1C_ADAPT/output/PDI_DS_TILE_LIST/S2A_OPER_MSI_L1C_TL_ATOS_20221121T053331_A038726_T45TXF_N04.00/" name="Check TECQUA for data loss " priority="5" processingStatus="done" status="FAILED"/>
+                    <message contentType="text/plain">There is data loss in this tile</message>
+                    <extraValues>
+                        <value name="Affected_Bands">B01 B02 B03 B04 B05 B06 B07 B08 B09 B10 B11 B12 B8A</value>
+                    </extraValues>
+                </check>
+            </checkList>
+        </report>
+    </Data_Block>
+</Earth_Explorer_File>

--- a/tests/test_apply_s2_quality_mask.py
+++ b/tests/test_apply_s2_quality_mask.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Tuple
+from typing import List, Tuple
 
 import numpy as np
 import pytest
@@ -11,8 +11,39 @@ from apply_s2_quality_mask.apply_s2_quality_mask import (
     JPEG2000_NO_COMPRESSION_OPTIONS,
     SPECTRAL_BANDS,
     apply_quality_mask,
+    find_affected_bands,
     find_image_mask_pairs,
 )
+
+TEST_DATA = Path(__file__).parents[0].joinpath("data", "quality-mask")
+
+
+@pytest.mark.parametrize(["granule_dir", "affected_bands"], [
+    pytest.param(
+        TEST_DATA / "L1C_T45TXF_A038726_20221121T050115",
+        ["B01", "B02", "B03", "B04", "B05", "B06", "B07", "B08", "B09", "B10", "B11", "B12", "B8A"],
+        id="All bands affected",
+    ),
+    pytest.param(
+        TEST_DATA / "L1C_T43QDG_A031305_20230305T053523",
+        ["B01", "B02", "B03", "B09", "B10", "B11", "B12", "B8A"],
+        id="Subset of bands affected",
+    ),
+    pytest.param(
+        TEST_DATA / "L1C_T12QXM_A048143_20240909T175112",
+        [],
+        id="No bands affected",
+    ),
+    pytest.param(
+        TEST_DATA,
+        SPECTRAL_BANDS,
+        id="No metadata file present",
+    )
+])
+def test_find_affected_bands(granule_dir: Path, affected_bands: List[str]):
+    """Test we find the bands affected by a quality issue correctly from metadata"""
+    test = find_affected_bands(granule_dir)
+    assert set(test) == set(affected_bands)
 
 
 def make_fake_s2_granule(
@@ -56,7 +87,7 @@ def test_find_image_mask_pairs_found_all(tmp_path: Path):
         expected_images_masks.append(make_fake_s2_granule(granule_prefix, band, mask_data))
 
     # Make sure we find all of the expected paths
-    image_mask_pairs = find_image_mask_pairs(tmp_path)
+    image_mask_pairs = find_image_mask_pairs(tmp_path, SPECTRAL_BANDS)
 
     for image_mask_pair in expected_images_masks:
         assert image_mask_pair in image_mask_pairs
@@ -74,7 +105,7 @@ def test_find_image_mask_pairs_found_not_all(tmp_path: Path):
         expected_images_masks.append(make_fake_s2_granule(granule_prefix, band, mask_data))
 
     # Make sure we find all of the expected paths
-    image_mask_pairs = find_image_mask_pairs(tmp_path)
+    image_mask_pairs = find_image_mask_pairs(tmp_path, SPECTRAL_BANDS)
     assert not image_mask_pairs
 
 

--- a/tests/test_apply_s2_quality_mask.py
+++ b/tests/test_apply_s2_quality_mask.py
@@ -1,0 +1,109 @@
+from pathlib import Path
+from typing import Tuple
+
+import numpy as np
+import pytest
+import rasterio
+from affine import Affine
+from rasterio.crs import CRS
+
+from apply_s2_quality_mask.apply_s2_quality_mask import (
+    JPEG2000_NO_COMPRESSION_OPTIONS,
+    SPECTRAL_BANDS,
+    apply_quality_mask,
+    find_image_mask_pairs,
+)
+
+
+def make_fake_s2_granule(
+    prefix: Path,
+    band: str,
+    mask_data: np.ndarray,
+) -> Tuple[Path, Path]:
+    """Create a fake S2 L1C granule"""
+
+    profile = {
+        "width": mask_data.shape[1],
+        "height": mask_data.shape[2],
+        "crs": CRS.from_epsg(32643),
+        "transform": Affine(10.0, 0.0, 399960.0, 0.0, -10.0, 2700000.0),
+        "driver": "JP2OpenJPEG",
+        **JPEG2000_NO_COMPRESSION_OPTIONS,
+    }
+
+    image_path = prefix / "IMG_DATA" / f"T45TXF_20221121T050121_{band}.jp2"
+    image_path.parent.mkdir(exist_ok=True, parents=True)
+    with rasterio.open(image_path, "w", count=1, dtype="uint16", **profile) as dst:
+        dst.write(np.ones(mask_data.shape[1:]), 1)
+
+    mask_path = prefix / "QI_DATA" / f"MSK_QUALIT_{band}.jp2"
+    mask_path.parent.mkdir(exist_ok=True, parents=True)
+    with rasterio.open(mask_path, "w", count=8, dtype="uint8", **profile) as dst:
+        dst.write(mask_data)
+
+    return image_path, mask_path
+
+
+def test_find_image_mask_pairs_found_all(tmp_path: Path):
+    """Test successfully finding location of all imagery data"""
+    granule_id = "L1C_T45TXF_A038726_20221121T050115"
+    granule_prefix = tmp_path / f"{granule_id}.SAFE" / "GRANULE" / granule_id
+
+    mask_data = np.zeros((8, 1, 1), dtype="uint8")
+
+    expected_images_masks = []
+    for band in SPECTRAL_BANDS:
+        expected_images_masks.append(make_fake_s2_granule(granule_prefix, band, mask_data))
+
+    # Make sure we find all of the expected paths
+    image_mask_pairs = find_image_mask_pairs(tmp_path)
+
+    for image_mask_pair in expected_images_masks:
+        assert image_mask_pair in image_mask_pairs
+
+
+def test_find_image_mask_pairs_found_not_all(tmp_path: Path):
+    """Test this is a no-op if we can't find all of the mask<>image pairs"""
+    granule_id = "L1C_T45TXF_A038726_20221121T050115"
+    granule_prefix = tmp_path / f"{granule_id}.SAFE" / "GRANULE" / granule_id
+
+    mask_data = np.zeros((8, 1, 1), dtype="uint8")
+
+    expected_images_masks = []
+    for band in list(SPECTRAL_BANDS)[:2]:
+        expected_images_masks.append(make_fake_s2_granule(granule_prefix, band, mask_data))
+
+    # Make sure we find all of the expected paths
+    image_mask_pairs = find_image_mask_pairs(tmp_path)
+    assert not image_mask_pairs
+
+
+def test_apply_quality_mask_overwrites_value(tmp_path: Path):
+    """Ensure image data are set to no data value (0) per mask band"""
+    # Mask is 2x2 with 4 test cases,
+    #   * (0, 0) ~> unmasked
+    #   * (0, 1) ~> lost MSI packet
+    #   * (1, 0) ~> degraded MSI packet
+    #   * (1, 1) ~> lost + degraded MSI packet (both set)
+    mask_data = np.zeros((8, 2, 2), dtype="uint8")
+    mask_data[2, 0, 1] = 1
+    mask_data[3, 1, 0] = 1
+    mask_data[2, 1, 1] = 1
+    mask_data[3, 1, 1] = 1
+    assert mask_data.sum() == 4
+
+    granule_id = "L1C_T45TXF_A038726_20221121T050115"
+    granule_prefix = tmp_path / f"{granule_id}.SAFE" / "GRANULE" / granule_id
+
+    image, mask = make_fake_s2_granule(granule_prefix, "B02", mask_data)
+
+    apply_quality_mask(image, mask)
+
+    # Check data ~> image should have 0s in 3 pixel locations
+    with rasterio.open(image) as src:
+        image_data = src.read(1)
+
+    np.testing.assert_array_equal(
+        image_data,
+        np.array([[1, 0], [0, 0]], dtype="uint16"),
+    )


### PR DESCRIPTION
## What I'm changing

This PR is intended to address this ticket, https://github.com/NASA-IMPACT/hls-sentinel/issues/155

This PR replaces the original PR (#14) that I submitted from a fork because my forked branch wasn't triggering CI tests.

Specifically this is intended to replace a utility written in C to apply a binary quality mask to Sentinel-2 L1C data that masks lost or degraded MSI pixel values. The original PR was, https://github.com/NASA-IMPACT/hls-sentinel/pull/152

This utility script is intended to fit into the rest of the HLS Sentinel-2 related processing. To apply the script we would need to do a few extra steps,

1. Merge this PR and create a new release in Github to point to (e.g., `hls-utilities@v1.10`)
2. Update the installation of `hls-utilities` in the `hls-sentinel` container to include this update (https://github.com/NASA-IMPACT/hls-sentinel/blob/20180e0d0cd286ffefe61bd6aeeaeff056874102/Dockerfile#L123)
3. Update the `hls-sentinel` processing steps to include running this script as part of `sentinel_granule.sh` (e.g., around here https://github.com/NASA-IMPACT/hls-sentinel/blob/20180e0d0cd286ffefe61bd6aeeaeff056874102/scripts/sentinel_granule.sh#L44)
4. Test
5. Update the `hls-sentinel` image used in our production pipelines by tagging our new container appropriately (i.e., "latest")


## How I did it

The ESA quality mask is an 8 band single bit image that encodes 0/1 for 8 quality related attributes. The bands we're interested in are bands 3 & 4 (counting from 1 in GDAL notation) which encode if the pixel retrieval was either lost or degraded.

I followed the original C code implementation with a few modifications...

1. Finds the mask + image pairs
    * The original C code will exit 1 if not all of the images have been found, or would exit 0 if the granule doesn't have the expected image/mask pair (e.g., prior to baseline `04.00`).
    * I wanted to ensure we don't hard fail if we can't apply the mask, and favored doing a "no-op" if the granule file structure isn't as we expect
2. Reads the 3rd and 4th bands of the mask
    * In the original implementation the JPEG2000 is first converted to an ENVI file, a binary in "band sequential" (BSQ) format. The C code reads all bands for the entire image and fills the imagery band if EITHER mask band 3 or 4 have a value of 1 for a pixel row/column.
    * In our implementation we can use GDAL to only read the 3rd and 4th bands
3. Updates the imagery in-place by assigning `HLS_REFL_FILLVAL` (`-9999`) to any pixel where the mask was TRUE for either band.
    * The `-9999` value is not suitable for us because the original L1C images in JPEG2000 format use `0` as the nodata value (since `-9999` is out of data type range)
    * The `0` value is used as a no data value for L1C imagery and this is noted in the metadata
    * I see in the `hls-sentinel` that some utilities modify in place while others create new data. If it'd be useful for a "debug mode" it would be easy to rewrite the images to new files


## How you can test it

Install the test dependencies and run unit tests for this script,
```
pip install -e .[test]
pytest tests/test_apply_s2_quality_mask.py
```

The unit tests are what helped me discover that JPEG2000 driver will apply lossy compression when we update the file (`r+` access mode) even though the original file had lossless compression in creation options 🙃

I ran this for one of the granules mentioned in the original C code PR and recorded a tiny demo,
![2025-01-02 16 45 12](https://github.com/user-attachments/assets/26f690ac-41e9-4de5-8d96-3ab4d9ef7a8a)
Note the "inspect tool" that shows the imagery values on the right hand side. The S2 L1C imagery don't have a No Data Value set, so QGIS shows the 0 as valid pixels. Still we can see the individual pixel values are correct (0 instead of ~1,000) and the image is stretched differently because of the different minimum values.