### PR TITLE
fix: universal newlines is now the default

### DIFF
--- a/.github/workflows/tox_tests.yml
+++ b/.github/workflows/tox_tests.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [3.9]
+        python: [3.6, 3.14]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/tox_tests.yml
+++ b/.github/workflows/tox_tests.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [3.6, 3.14]
+        python: [3.9, 3.14]
 
     steps:
       - uses: actions/checkout@v2

--- a/check_solar_zenith_landsat/mtlutils.py
+++ b/check_solar_zenith_landsat/mtlutils.py
@@ -282,14 +282,14 @@ def parsemeta(metadataloc):
                 % metadataloc)
         elif len(metalist) > 0:
             metadatafn = metalist[0]
-            filehandle = open(metadatafn, 'rU')
+            filehandle = open(metadatafn, 'r')
             if len(metalist) > 1:
                 logging.warning(
                     "More than one file in directory match metadata "
                     + "file pattern. Using %s." % metadatafn)
     elif os.path.isfile(metadataloc):
         metadatafn = metadataloc
-        filehandle = open(metadatafn, 'rU')
+        filehandle = open(metadatafn, 'r')
         logging.info("Using file %s." % metadatafn)
     elif 'L1_METADATA_FILE' in metadataloc:
         filehandle = StringIO.StringIO(metadataloc)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="hls-utilities",
-    version="1.11.2",
+    version="1.11.3",
     packages=find_packages(),
     install_requires=[
         "click",

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     include_package_data=True,
     extras_require={
         "dev": ["ruff"],
-        "test": ["ruff", "pytest", "Jinja2==2.10.1", "moto[s3]~=2.0.8", "markupsafe==2"]
+        "test": ["ruff", "pytest", "Jinja2==2.10.1", "moto[s3]", "markupsafe==2"]
     },
     entry_points={"console_scripts": [
         "apply_s2_quality_mask=apply_s2_quality_mask.apply_s2_quality_mask:main",

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     include_package_data=True,
     extras_require={
         "dev": ["ruff"],
-        "test": ["ruff", "pytest", "Jinja2==2.10.1", "moto[s3]", "markupsafe==2"]
+        "test": ["ruff", "pytest", "Jinja2", "moto[s3]", "markupsafe==2"]
     },
     entry_points={"console_scripts": [
         "apply_s2_quality_mask=apply_s2_quality_mask.apply_s2_quality_mask:main",

--- a/tests/test_download_landsat.py
+++ b/tests/test_download_landsat.py
@@ -3,7 +3,7 @@ import io
 import pytest
 import boto3
 from click.testing import CliRunner
-from moto import mock_s3
+from moto import mock_aws
 from download_landsat.download_landsat import get_landsat, main
 from download_landsat.download_landsat import KeyDoesNotExist
 
@@ -33,7 +33,7 @@ def aws_credentials():
 
 @pytest.fixture(scope="function")
 def s3(aws_credentials):
-    with mock_s3():
+    with mock_aws():
         client = boto3.client("s3", region_name="us-east-1")
         client.create_bucket(Bucket=BUCKET)
         client.put_bucket_request_payment(


### PR DESCRIPTION
## Description

On modern Python the `open("file.txt", "rU")` gives this error,
```python
ValueError: invalid mode: 'rU'
```

The `"U"` in `"rU"` is for "universal newline" mode. This setting was removed in Python 3.11 and was the default since Python 3.0, so we can safely remove it for Python 3.6 (old orchestration container) and modern versions (new orchestration container).